### PR TITLE
add pagination logic in index.js

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,7 +12,9 @@ const IndexPage = ({ data }) => {
   const posts = data.allMarkdownRemark.edges
   const labels = data.site.siteMetadata.labels
   const currentPage = 1
+  const postsPerPage = 3 // see graphql limit
   const nextPage = (currentPage + 1).toString()
+  const hasNextPage = data.allMarkdownRemark.totalCount > postsPerPage
 
   const getTechTags = (tags) => {
     const techTags = []
@@ -60,11 +62,13 @@ const IndexPage = ({ data }) => {
               </div>
             )
           })}
-          <div className="mt-4 text-center">
-            <Link to={nextPage} rel="next" style={{ textDecoration: `none` }}>
-              <span className="text-dark">Next Page →</span>
-            </Link>
-          </div>
+          {hasNextPage &&
+            <div className="mt-4 text-center">
+              <Link to={nextPage} rel="next" style={{ textDecoration: `none` }}>
+                <span className="text-dark">Next Page →</span>
+              </Link>
+            </div>
+          }
         </div>
       </div>
     </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,7 +12,7 @@ const IndexPage = ({ data }) => {
   const posts = data.allMarkdownRemark.edges
   const labels = data.site.siteMetadata.labels
   const currentPage = 1
-  const postsPerPage = 3 // see graphql limit
+  const postsPerPage = 3 // see limit in graphql query below
   const nextPage = (currentPage + 1).toString()
   const hasNextPage = data.allMarkdownRemark.totalCount > postsPerPage
 


### PR DESCRIPTION
Thank you for your `gatsby-starter-developer-diary`!
I am developing my tech blog with your starter kit.
By the way, I found that next-page link in index page is always shown.
So in this pull request, I added a logic to determine having next blog-list page or not in `src/index.js`.
I think this change might be better for blog readers.

# Overview
Add pagination login in src/index.js

# Current
- Always show next-page link on index page

# In this pull request
- Show next page link only on number of posted article is more than 3

Thank you.
