### PR TITLE
Change markdown limit to 1000

### DIFF
--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -34,7 +34,7 @@ const Sidebar = () => {
                         }
                     }
                     allMarkdownRemark(
-                        limit: 10
+                        limit: 1000
                         sort: { fields: [frontmatter___date], order: DESC }
                         filter: { frontmatter: { published: { eq: true } } }
                     ) {


### PR DESCRIPTION
My friend was having issues where any tags from posts beyond the 10 most recent posts weren't showing up in the tech-tags in the sidebar.

I changed the limit parameter in Sidebar.js to 1000 and it fixed the issue, so my friend suggested other users new to your starter-pack might have similar issues.

So, I'm presenting this to you. Hope that's ok.